### PR TITLE
Fix mobile system logs layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -747,7 +747,7 @@
     }
 
     /* Floating system logs panel */
-    #systemLogsContainer {
+    .system-logs {
         position: fixed;
         top: 100px;
         right: 20px;
@@ -759,12 +759,14 @@
         z-index: 10000;
     }
 
-    @media (max-width: 640px) {
-        #systemLogsContainer {
-            top: 100px;
-            right: 10px;
-            width: calc(100% - 20px);
+    @media (max-width: 768px) {
+        .system-logs {
+            position: relative;
+            top: auto;
+            right: auto;
+            width: 100%;
             max-width: none;
+            margin-top: 1rem;
         }
     }
 
@@ -892,7 +894,7 @@
 
 
         <!-- Floating System Logs -->
-        <div class="terminal-border bg-black bg-opacity-50 p-3 space-y-2" id="systemLogsContainer">
+        <div class="terminal-border bg-black bg-opacity-50 p-3 space-y-2 system-logs" id="systemLogsContainer">
             <div class="pixel-text-sm text-green-500 text-xs mb-2 cursor-pointer text-right" id="systemLogsHeader">[SYSTEM_LOGS]</div>
             <div class="pixel-text-xs text-green-400 space-y-1 max-h-32 overflow-y-auto" id="systemLogs">
                 <div>> AI_CORE: Initializing...</div>


### PR DESCRIPTION
## Summary
- address layout bug where `[SYSTEM_LOGS]` overlaps content on small screens
- make system logs container responsive via `.system-logs` class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bb6fa88508326b6abf3df8d0a32da