### PR TITLE
Add collapsible system logs panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,30 +749,35 @@
     /* Floating system logs panel */
     .system-logs {
         position: fixed;
-        bottom: 60px;
-        left: 20px;
+        bottom: 40px;
+        left: 10px;
         width: 260px;
-        max-height: 130px;
+        max-height: 150px;
         overflow-y: auto;
-        opacity: 0;
-        transition: max-height 0.3s ease, opacity 0.3s ease;
+        font-family: monospace;
+        color: #00BFFF;
+        opacity: 1;
+        transform: translateY(0);
+        transition: opacity 0.3s ease, transform 0.3s ease;
         z-index: 10000;
     }
 
     #logsToggle {
         position: fixed;
-        bottom: 20px;
-        left: 20px;
+        bottom: 10px;
+        left: 10px;
         z-index: 10001;
+        width: 22px;
+        height: 22px;
         background-color: black;
         color: #00ff00;
         font-family: monospace;
         font-weight: bold;
-        padding: 6px 10px;
-        border: 2px dashed #00ff00;
-        text-shadow: 0 0 1px #00ff00, 0 0 2px #00ff00;
+        border: 2px solid #00ff00;
+        line-height: 18px;
+        text-align: center;
         cursor: pointer;
-        animation: logsGlow 2s ease-in-out infinite;
+        transition: background-color 0.2s ease;
     }
 
     @keyframes logsGlow {
@@ -793,19 +798,23 @@
     }
 
     #systemLogsContainer.collapsed {
-        max-height: 0;
         opacity: 0;
+        transform: translateY(10px);
         pointer-events: none;
+    }
+
+    #systemLogsContainer {
+        transform: translateY(0);
     }
 
     @media (max-width: 768px) {
         .system-logs {
-            bottom: 60px;
+            bottom: 50px;
             left: 10px;
             width: 90%;
         }
         #logsToggle {
-            bottom: 20px;
+            bottom: 10px;
             left: 10px;
         }
     }
@@ -934,9 +943,9 @@
 
 
         <!-- Floating System Logs -->
-        <div class="terminal-border bg-black bg-opacity-50 p-3 space-y-2 system-logs" id="systemLogsContainer">
-            <div class="pixel-text-sm text-green-500 text-xs mb-2 cursor-pointer text-right" id="systemLogsHeader">[SYSTEM_LOGS]</div>
-            <div class="pixel-text-xs text-green-400 space-y-1 max-h-32 overflow-y-auto" id="systemLogs">
+        <div class="terminal-border bg-black bg-opacity-50 p-3 space-y-2 system-logs collapsed" id="systemLogsContainer">
+            <div class="pixel-text-sm text-xs mb-2 cursor-pointer text-right" style="color:#00BFFF;font-family:monospace;" id="systemLogsHeader">[SYSTEM_LOGS]</div>
+            <div class="pixel-text-xs space-y-1 max-h-32 overflow-y-auto" style="color:#00BFFF;font-family:monospace;" id="systemLogs">
                 <div>> AI_CORE: Initializing...</div>
                 <div>> VISUAL_PROC: Loading algorithms...</div>
                 <div>> CREATIVITY_ENGINE: Activating...</div>
@@ -946,7 +955,7 @@
             </div>
         </div>
     </div>
-    <button id="logsToggle">[-]</button>
+    <button id="logsToggle">[+]</button>
 
     <!-- SOCIAL Button Container -->
     <div id="socialContainer" class="pxl-frame">


### PR DESCRIPTION
## Summary
- add SYSTEM_LOGS panel with blue monospaced text
- toggle via green + icon in bottom-left corner
- smooth transitions for showing/hiding panel

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684bbde0706c8326833d648e73fa54df