### PR TITLE
Fix bottom terminal overlap and remove social glow

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,24 +623,7 @@
         border: 2px dashed #FFA500;
         text-shadow: 0 0 1px #FFA500, 0 0 2px #FFA500;
         cursor: pointer;
-        animation: socialGlow 2s ease-in-out infinite;
-    }
-
-    @keyframes socialGlow {
-        0%, 100% {
-          box-shadow:
-            0 0 2px #FFA500,
-            0 0 6px #FFA500,
-            0 0 12px #ffb347,
-            0 0 24px #ffb347;
-        }
-        50% {
-          box-shadow:
-            0 0 4px #FFA500,
-            0 0 8px #FFA500,
-            0 0 16px #ffb347,
-            0 0 32px #ffb347;
-        }
+        box-shadow: none;
     }
 
     .terminal-activate {
@@ -972,10 +955,10 @@
     </div>
 
     <!-- Footer Command Line -->
-    <div class="absolute bottom-4 left-4 right-4" style="z-index: 5;">
+    <div class="absolute bottom-4 left-4 right-4" style="z-index: 5;" id="footerTerminal">
         <div class="terminal-border bg-black p-2">
             <div class="text-sm pixel-text-sm">
-                <span class="text-green-400">root@ghostline:~$</span> 
+                <span class="text-green-400">root@ghostline:~$</span>
                 <span class="glow-text">initiate_art_sequence</span>
                 <span class="blink ml-2">█</span>
             </div>
@@ -1114,11 +1097,13 @@
     function setupLogsToggle() {
         const toggleBtn = safeGetElement('logsToggle');
         const container = safeGetElement('systemLogsContainer');
+        const footer = safeGetElement('footerTerminal');
 
         if (toggleBtn && container) {
             toggleBtn.addEventListener('click', function() {
                 const collapsed = container.classList.toggle('collapsed');
                 toggleBtn.textContent = collapsed ? '[+]' : '[-]';
+                if (footer) footer.style.display = collapsed ? '' : 'none';
             });
         }
     }
@@ -1499,7 +1484,12 @@
                     setTimeout(() => {
                         document.getElementById('terminal-loading').style.display = 'none';
                         const logs = document.getElementById('systemLogsContainer');
-                        if (logs) logs.classList.add('open');
+                        const footer = document.getElementById('footerTerminal');
+                        if (logs) {
+                            logs.classList.add('open');
+                            logs.classList.remove('collapsed');
+                        }
+                        if (footer) footer.style.display = 'none';
                     }, 300);
                 }, 300);
             }


### PR DESCRIPTION
## Summary
- hide the footer command line when the system log panel is visible
- strip the continuous glow animation from the SOCIAL button
- automatically remove the bottom line when logs open after loading

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684bcf78219c83269bb944c6516dc1cd