### PR TITLE
Add random glyph next to coin icon

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -603,7 +603,11 @@
 </div>
 
 <script>
-    const priceSymbols = ['⟁', '✶', '⚗', '⌁', '🜁', '☍'];
+    const priceSymbols = [
+        '⟁', '✶', '⚗', '⌁', '⟁',
+        '⟡', '⋔', '𓂀', '𐂂',
+        '🜂', '🝊', '☍', '⟁'
+    ];
     const priceSymbol = priceSymbols[Math.floor(Math.random() * priceSymbols.length)];
     // Load artworks from localStorage
     let galleryItems = JSON.parse(localStorage.getItem('ghostline_artworks') || '[]');


### PR DESCRIPTION
## Summary
- display a pixel-styled random symbol next to the coin icon
- extend the glyph list and pick one at page load

## Testing
- `npm install`
- `npm start` *(server run briefly)*

------
https://chatgpt.com/codex/tasks/task_e_684c4ad3c4108326be444c8b26c480ef