### PR TITLE
Replace price text with cryptic symbol strip

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -609,6 +609,21 @@
         '🜂', '🝊', '☍', '⟁'
     ];
     const priceSymbol = priceSymbols[Math.floor(Math.random() * priceSymbols.length)];
+
+    const symbolPool = [
+        '𐃉', '⧛', '☍', '⟁', '𐂂',
+        '⋔', '𓂀', '⧈', '⟡',
+        '🜂', '🝊'
+    ];
+    function generateSymbolStrip() {
+        const length = 8 + Math.floor(Math.random() * 5);
+        const result = [];
+        for (let i = 0; i < length; i++) {
+            result.push(symbolPool[Math.floor(Math.random() * symbolPool.length)]);
+        }
+        return result.join(' ');
+    }
+    const symbolStrip = generateSymbolStrip();
     // Load artworks from localStorage
     let galleryItems = JSON.parse(localStorage.getItem('ghostline_artworks') || '[]');
     let currentCategory = 'all';
@@ -676,7 +691,7 @@
                     <div class="price-display flex items-center gap-2 mt-2">
                         <img src="ghostcoin.gif" alt="coin" class="coin-icon">
                         <span class="price-symbol pixel-text glow-text">${priceSymbol}</span>
-                        <span class="text-sm">${item.price ? item.price + ' ETH' : 'Contact for price'}</span>
+                        <span class="text-sm symbol-strip">${item.price ? item.price + ' ETH' : symbolStrip}</span>
                     </div>
                 </div>
             </div>
@@ -696,7 +711,7 @@
             artwork.status === 'available' ? 'Available' :
             artwork.status === 'sold' ? 'Sold' :
             artwork.status === 'lost' ? 'Lost' : 'Ghost';
-        document.getElementById('detailPrice').textContent = artwork.price ? artwork.price + ' ETH' : 'Contact for price';
+        document.getElementById('detailPrice').textContent = artwork.price ? artwork.price + ' ETH' : symbolStrip;
         document.getElementById('detailDescription').textContent = artwork.description || 'No description available.';
         document.getElementById('detailDimensions').textContent = artwork.dimensions || 'Not specified';
         document.getElementById('detailMedium').textContent = artwork.medium || 'Digital';

--- a/style.css
+++ b/style.css
@@ -89,12 +89,23 @@
         }
     }
     
-    .pixel-text-sm {
-        font-family: 'Share Tech Mono', monospace;
-        color: #00ff00;
-        font-size: 12px;
-        letter-spacing: 1px;
-    }
+.pixel-text-sm {
+    font-family: 'Share Tech Mono', monospace;
+    color: #00ff00;
+    font-size: 12px;
+    letter-spacing: 1px;
+}
+
+.symbol-strip {
+    font-family: 'Share Tech Mono', monospace;
+    color: #00ff00;
+    text-shadow: 0 0 4px #0f0, 0 0 6px #0f0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    max-width: 100%;
+}
 
     .logo-subtitle {
         font-family: 'Share Tech Mono', monospace;


### PR DESCRIPTION
## Summary
- create a symbol strip generator that makes a random sequence on page load
- show symbol strip instead of 'Contact for price'
- add CSS for the neon symbol strip

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684c4cde87d8832686171e5e0323219b