### PR TITLE
Add ATA glyph square

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,6 +618,42 @@
     setTimeout(() => toggle.classList.remove("terminal-activate"), 500);
   });
 </script>
+<div id="ata-line" class="ata-glyph-line">█ ⚚ ⌁ ⏚ ⑂</div>
+<div id="ata-square" class="ata-glyph-square"></div>
+<script>
+const ataGlyphs = ["█","▓","▒","░","⧉","⚚","☲","⑂","⌬","⌁","⌖","⌿","⏚","⸸","⛧","⍟","⏣","⏃","⬟","⌇","⌘","☍","⚷","⋔","⸮","⋇","⫷","⫸"];
+function getRandomATASet(count = 5) {
+  const picked = [];
+  while (picked.length < count) {
+    const g = ataGlyphs[Math.floor(Math.random()*ataGlyphs.length)];
+    if (!picked.includes(g)) picked.push(g);
+  }
+  return picked.join(" ");
+}
+function getRandomATASquare(size = 5) {
+  let rows = [];
+  for (let i=0; i<size; i++) {
+    let row = [];
+    for (let j=0; j<size; j++) {
+      row.push(ataGlyphs[Math.floor(Math.random()*ataGlyphs.length)]);
+    }
+    rows.push(row.join(" "));
+  }
+  return rows.join("\n");
+}
+setInterval(() => {
+  const line = document.getElementById("ata-line");
+  if (line) line.textContent = getRandomATASet();
+  const square = document.getElementById("ata-square");
+  if (square) square.textContent = getRandomATASquare();
+}, 5000);
+document.addEventListener("DOMContentLoaded", () => {
+  const line = document.getElementById("ata-line");
+  if (line) line.textContent = getRandomATASet();
+  const square = document.getElementById("ata-square");
+  if (square) square.textContent = getRandomATASquare();
+});
+</script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -681,3 +681,20 @@
         100% { transform: scale(1); opacity: 1; }
     }
 
+.ata-glyph-line,
+.ata-glyph-square {
+    font-family: monospace;
+    font-size: 24px;
+    color: #00ff00;
+    background: #000000;
+    display: inline-block;
+    padding: 4px 12px;
+}
+.ata-glyph-line {
+    letter-spacing: 8px;
+}
+.ata-glyph-square {
+    line-height: 1.2;
+    white-space: pre;
+    margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- display ATA glyphs in a square
- style ATA glyph containers

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c51dbc7c08326849de58f8663e199