### PR TITLE
Fix admin export to Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+supabase-env.js
+node_modules/

--- a/admin.html
+++ b/admin.html
@@ -21,11 +21,11 @@
     
     .terminal-border {
         border: 2px solid #00ff00;
-        box-shadow: 0 0 15px rgba(0, 255, 0, 0.3);
+        box-shadow: none;
     }
-    
+
     .glow-text {
-        text-shadow: 0 0 8px #00ff00, 0 0 16px #00ff00;
+        text-shadow: none;
     }
 
     .no-glow {
@@ -61,7 +61,7 @@
     
     .admin-input:focus {
         outline: none;
-        box-shadow: 0 0 10px rgba(0, 255, 0, 0.5);
+        box-shadow: none;
     }
     
     .admin-button {
@@ -77,7 +77,7 @@
     .admin-button:hover {
         background: #00ff00;
         color: #000000;
-        box-shadow: 0 0 15px rgba(0, 255, 0, 0.5);
+        box-shadow: none;
     }
     
     .admin-button.danger {
@@ -112,17 +112,17 @@
         margin-right: 8px;
     }
     
-    .status-available { 
-        background: #00ff00; 
-        box-shadow: 0 0 10px #00ff00;
+    .status-available {
+        background: #00ff00;
+        box-shadow: none;
     }
-    .status-sold { 
-        background: #ff0000; 
-        box-shadow: 0 0 10px #ff0000;
+    .status-sold {
+        background: #ff0000;
+        box-shadow: none;
     }
-    .status-ghost { 
-        background: #888888; 
-        box-shadow: 0 0 10px #888888;
+    .status-ghost {
+        background: #888888;
+        box-shadow: none;
     }
     
     .login-screen {
@@ -172,12 +172,12 @@
     }
     
     .nav-link:hover {
-        text-shadow: 0 0 10px #00ff00;
+        text-shadow: none;
     }
     
     .nav-active {
         color: #ffffff;
-        text-shadow: 0 0 10px #00ff00;
+        text-shadow: none;
     }
 
     @keyframes blink {
@@ -387,7 +387,7 @@
 
 <script>
     // Admin authentication
-    const ADMIN_PASSWORD = 'GL_admin2025!';
+    const ADMIN_PASSWORD = 'astral-vault-702';
     let artworks = [];
     
     // Safely load artworks from localStorage
@@ -645,15 +645,23 @@
         }
     }
 
-    function exportData() {
-        const dataStr = JSON.stringify(artworks, null, 2);
-        const dataBlob = new Blob([dataStr], {type: 'application/json'});
-        const url = URL.createObjectURL(dataBlob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'ghostline_artworks.json';
-        link.click();
-        URL.revokeObjectURL(url);
+    async function exportData() {
+        if (!window.supabaseAdmin) {
+            alert('Supabase not initialized');
+            return;
+        }
+        for (const artwork of artworks) {
+            try {
+                if (artwork.image && artwork.image.startsWith('data:')) {
+                    const url = await window.supabaseAdmin.uploadArtworkImage(artwork.id, artwork.image);
+                    artwork.image = url;
+                }
+                await window.supabaseAdmin.saveArtworkToDB(artwork);
+            } catch (err) {
+                console.error('Export error:', err);
+            }
+        }
+        alert('Export complete!');
     }
 
     function importData() {
@@ -694,6 +702,7 @@
     });
 </script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+<script src="supabase-env.js"></script>
 <script src="supabase-admin.js"></script>
 
 </body>

--- a/generate-env.js
+++ b/generate-env.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+const url = process.env.SUPABASE_URL || '';
+const anon = process.env.SUPABASE_ANON_KEY || '';
+const content = `window.SUPABASE_URL = '${url}';\nwindow.SUPABASE_ANON_KEY = '${anon}';`;
+fs.writeFileSync('supabase-env.js', content);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Static deployment of ghostline-web via Railway",
   "scripts": {
-    "start": "serve ."
+    "start": "node generate-env.js && serve ."
   },
   "dependencies": {
     "serve": "^14.2.4"

--- a/supabase-admin.js
+++ b/supabase-admin.js
@@ -1,64 +1,38 @@
-// Supabase admin panel integration
-// This script assumes that the Supabase JS SDK is loaded globally via CDN
-// <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-
 (function(){
-  const SUPABASE_URL = 'https://alqavrioetqfylwkqmak.supabase.co';
-  const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFscWF2cmlvZXRxZnlsd2txbWFrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk4MTgyNDksImV4cCI6MjA2NTM5NDI0OX0.V7cQfoAat4LFC0zvye6B8W3ELNSA2kZE0D-If_fGfdc';
-
-  // initialize Supabase client
+  const SUPABASE_URL = window.SUPABASE_URL || '';
+  const SUPABASE_KEY = window.SUPABASE_ANON_KEY || '';
   const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
 
-  const form = document.getElementById('artworkForm');
-  const imageInput = document.getElementById('imageInput');
-
   async function ensureBucket(name) {
-    // tries to create the bucket if it doesn't exist
-    // anonymous key might not have permission; ignore errors
-    try {
-      await supabase.storage.createBucket(name, { public: true });
-    } catch (err) {
-      // bucket may already exist or creation not allowed
-      console.warn('createBucket error:', err.message);
-    }
+    try { await supabase.storage.createBucket(name, { public: true }); }
+    catch (err) { console.warn('createBucket error:', err.message); }
   }
 
-  async function uploadImage(file) {
+  function dataUrlToBlob(dataUrl) {
+    const [meta, base64] = dataUrl.split(',');
+    const contentType = meta.split(':')[1].split(';')[0];
+    const binary = atob(base64);
+    const arr = new Uint8Array(binary.length);
+    for (let i=0;i<binary.length;i++) arr[i] = binary.charCodeAt(i);
+    return new Blob([arr], { type: contentType });
+  }
+
+  async function uploadArtworkImage(id, dataUrl) {
     const bucket = 'artworks';
     await ensureBucket(bucket);
-    const fileExt = file.name.split('.').pop();
-    const fileName = `${crypto.randomUUID()}.${fileExt}`;
-    const { data, error } = await supabase.storage.from(bucket).upload(fileName, file);
+    const extMatch = dataUrl.substring(5).split(';')[0].split('/')[1];
+    const fileName = `${id}.${extMatch}`;
+    const blob = dataUrlToBlob(dataUrl);
+    const { data, error } = await supabase.storage.from(bucket).upload(fileName, blob, { upsert: true });
     if (error) throw error;
     const { data: { publicUrl } } = supabase.storage.from(bucket).getPublicUrl(data.path);
     return publicUrl;
   }
 
-  async function saveMetadata(url) {
-    const { data, error } = await supabase.from('images').insert({ url }).select();
+  async function saveArtworkToDB(artwork) {
+    const { error } = await supabase.from('artworks').insert([artwork]);
     if (error) throw error;
-    return data[0];
   }
 
-  async function handleSubmit(event) {
-    event.preventDefault();
-    const file = imageInput.files[0];
-    if (!file) {
-      alert('Please choose an image to upload.');
-      return;
-    }
-    try {
-      const publicUrl = await uploadImage(file);
-      await saveMetadata(publicUrl);
-      alert('Image uploaded successfully!');
-      form.reset();
-    } catch (err) {
-      console.error('Upload error:', err);
-      alert('Error uploading image.');
-    }
-  }
-
-  if (form) {
-    form.addEventListener('submit', handleSubmit);
-  }
+  window.supabaseAdmin = { uploadArtworkImage, saveArtworkToDB };
 })();


### PR DESCRIPTION
## Summary
- generate `supabase-env.js` from Railway env vars
- disable green glow effects in admin UI
- update admin login password and include Supabase env script
- upload images to Supabase and save metadata when exporting
- add Supabase helper functions
- ignore generated files

## Testing
- `npm install`
- `npm start` *(fails: serve cannot run due to missing dependencies or network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684f7ae523f48326ab9a9016561ba1ef