### PR TITLE
Integrate Supabase upload for admin images

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -524,7 +524,7 @@
 
         try {
             if (currentImageData && currentImageData.startsWith('data:') && window.supabaseAdmin) {
-                artwork.image = await window.supabaseAdmin.uploadArtworkImage(newId, currentImageData);
+                artwork.image = await window.supabaseAdmin.uploadImage(currentImageData);
             }
             if (window.supabaseAdmin) {
                 await window.supabaseAdmin.saveArtworkToDB(artwork);

--- a/supabase-admin.js
+++ b/supabase-admin.js
@@ -17,13 +17,14 @@
     return new Blob([arr], { type: contentType });
   }
 
-  async function uploadArtworkImage(id, dataUrl) {
-    const bucket = 'artworks';
+  async function uploadImage(dataUrl) {
+    const bucket = 'public';
     await ensureBucket(bucket);
-    const extMatch = dataUrl.substring(5).split(';')[0].split('/')[1];
-    const fileName = `${id}.${extMatch}`;
+    const ext = dataUrl.substring(5).split(';')[0].split('/')[1];
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const fileName = `${unique}.${ext}`;
     const blob = dataUrlToBlob(dataUrl);
-    const { data, error } = await supabase.storage.from(bucket).upload(fileName, blob, { upsert: true });
+    const { data, error } = await supabase.storage.from(bucket).upload(fileName, blob);
     if (error) throw error;
     const { data: { publicUrl } } = supabase.storage.from(bucket).getPublicUrl(data.path);
     return publicUrl;
@@ -40,5 +41,5 @@
     return Array.isArray(data) && data.length > 0;
   }
 
-  window.supabaseAdmin = { uploadArtworkImage, saveArtworkToDB, artworkExists };
+  window.supabaseAdmin = { uploadImage, saveArtworkToDB, artworkExists };
 })();


### PR DESCRIPTION
## Summary
- upload images from admin panel directly to Supabase Storage
- store uploaded images in the `public` bucket with unique filenames
- update the save logic to use the new upload function

## Testing
- `npm install`
- `node generate-env.js`

------
https://chatgpt.com/codex/tasks/task_e_684f8adf60a08326925dd440770ba46b