### PR TITLE
Fix storing Supabase public image URLs

### DIFF
--- a/supabase-admin.js
+++ b/supabase-admin.js
@@ -45,6 +45,7 @@ class SupabaseAdmin {
                 .from(this.BUCKET_NAME)
                 .getPublicUrl(uniqueFilename);
 
+            // Return the resulting URL
             return publicUrlData.publicUrl;
             
         } catch (error) {
@@ -57,6 +58,10 @@ class SupabaseAdmin {
     async saveArtworkToDB(artwork) {
         try {
             console.log('Saving artwork to database:', artwork);
+
+            if (!artwork.url) {
+                throw new Error('Image URL cannot be empty');
+            }
 
             let query;
             if (artwork.id) {


### PR DESCRIPTION
## Summary
- reject empty URLs when saving artwork data
- clarify upload logic and return the generated public URL

## Testing
- `npm install`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684fed0c0ee483268f5486394b1648d2