### PR TITLE
Add GlyphTicker component

### DIFF
--- a/components/GlyphTicker.css
+++ b/components/GlyphTicker.css
@@ -1,0 +1,17 @@
+.glyph-ticker {
+  display: flex;
+  white-space: nowrap;
+  overflow: hidden;
+  color: #33ff33;
+  font-family: "Courier New", monospace;
+  font-size: 1.25rem;
+}
+.glyph-ticker span {
+  display: inline-block;
+  padding: 0 0.1em;
+  animation: flicker 1s infinite;
+}
+@keyframes flicker {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}

--- a/components/GlyphTicker.tsx
+++ b/components/GlyphTicker.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useRef } from 'react';
+import './GlyphTicker.css';
+
+const glyphs = [
+  '█','▓','▒','░','▖','▗','▘','▝','▚','▞','▛','▜','▟','▙','▁','▂','▃','▄','▅','▆','▇','◼','◻','▣','▤','▥','▦','▧','▨','▩','⬒','⬓','⬔','⬕','❒','❖','☐','☑','☒','⧈','⧉','⧠','⧃','⧂'
+];
+
+export default function GlyphTicker() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const interval = setInterval(() => {
+      if (container.firstChild) {
+        const first = container.firstChild as Node;
+        container.appendChild(first.cloneNode(true));
+        container.removeChild(first);
+      }
+    }, 150);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="glyph-ticker">
+      {glyphs.map((g, idx) => (
+        <span key={idx}>{g}</span>
+      ))}
+    </div>
+  );
+}

--- a/pages/gallery.tsx
+++ b/pages/gallery.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import GlyphTicker from '../components/GlyphTicker';
+import '../style.css';
+
+export default function Gallery() {
+  return (
+    <div className="min-h-screen bg-black text-green-500 flex flex-col items-center p-4">
+      <h1 className="text-2xl mb-4 font-bold">GHOSTLINE GALLERY</h1>
+      <img src="/IMG_2135.gif" alt="Artwork" className="w-full max-w-md" />
+      <div className="mt-4 w-full overflow-hidden">
+        <GlyphTicker />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GlyphTicker` component with CSS animation
- create a minimal `gallery.tsx` page that shows an artwork image and ticker

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ffd4d7d108326b36a1f01b6d199f7