### PR TITLE
Fix GlyphTicker clipping on gallery page

### DIFF
--- a/pages/gallery.tsx
+++ b/pages/gallery.tsx
@@ -7,7 +7,7 @@ export default function Gallery() {
     <div className="min-h-screen bg-black text-green-500 flex flex-col items-center p-4">
       <h1 className="text-2xl mb-4 font-bold">GHOSTLINE GALLERY</h1>
       <img src="/IMG_2135.gif" alt="Artwork" className="w-full max-w-md" />
-      <div className="mt-4 w-full overflow-hidden">
+      <div className="mt-4 w-full py-2">
         <GlyphTicker />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure GlyphTicker container allows space for ticker

## Testing
- `npm start` *(fails: cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685001a329948326a3bb0ee01319d501