### PR TITLE
Fix gallery layout clipping

### DIFF
--- a/pages/gallery.tsx
+++ b/pages/gallery.tsx
@@ -36,7 +36,7 @@ export default function Gallery() {
 
       <div className="flex flex-wrap items-center justify-center mt-4 gap-4">
         <img src="/ghostcoin.gif" alt="Ghost Coin" className="w-16 h-16" />
-        <div className="flex">
+        <div className="flex flex-wrap justify-center">
           {[0, 1, 2, 3, 4].map((idx) => (
             <AnimatedSymbol key={idx} index={idx} />
           ))}

--- a/style.css
+++ b/style.css
@@ -10,18 +10,18 @@
         font-family: 'Share Tech Mono', monospace;
         margin: 0;
         padding: 0;
-        height: 100vh;
-        overflow: hidden;
+        min-height: 100%;
+        overflow-y: auto;
     }
     
     .slide-container {
         width: 100%;
         max-width: 1280px;
-        height: 100vh;
+        min-height: 100vh;
         margin: 0 auto;
         position: relative;
         background: #000000;
-        overflow: hidden;
+        overflow-y: auto;
     }
     
     .terminal-border {


### PR DESCRIPTION
## Summary
- allow page scrolling by removing 100vh restriction on `html` and `body`
- allow `slide-container` content to grow and scroll
- ensure gallery glyph row wraps on small screens

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6850c73747608326ae275967f55ea734