### PR TITLE
Add PDF opener for logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,5 +738,16 @@ initATASquare();
 });
 </script>
 
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var logoImg = document.getElementById('logo');
+    if (logoImg) {
+      logoImg.addEventListener('click', function () {
+        window.open('https://alqavrioetqfylwkqmak.supabase.co/storage/v1/object/public/images//ghostlinecodex.pdf', '_blank');
+      });
+    }
+  });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- open the Ghostline Codex PDF when clicking the `logo` image

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68527bba1d688326963f9b0c9ca0aaf4