### PR TITLE
Add delayed terminal popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -772,7 +772,11 @@ initATASquare();
         }
         pagesSection.classList.remove('hidden');
         pagesSection.scrollIntoView({ behavior: 'smooth' });
-        if (popup) popup.style.display = 'block';
+        if (popup) {
+          setTimeout(function () {
+            popup.style.display = 'block';
+          }, 1000);
+        }
       });
     }
     if (closeBtn && popup) {


### PR DESCRIPTION
## Summary
- show terminal-style popup 1 second after clicking the logo
- keep popup hidden by default using CSS
- install dependencies and start server for basic check

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685394ebd6548326b740af922d4e0255