### PR TITLE
Add portal popup triggered by logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
     <div id="terminal-popup">
         <div id="terminal-close">X</div>
     </div>
+    <div id="portalPanel">PORTAL ACTIVATED</div>
 
 </main>
 
@@ -759,6 +760,8 @@ initATASquare();
     var pagesSection = document.getElementById('pages-section');
     var popup = document.getElementById('terminal-popup');
     var closeBtn = document.getElementById('terminal-close');
+    var portalPanel = document.getElementById('portalPanel');
+    var portalShown = false;
     if (logoImg && pagesSection) {
       logoImg.addEventListener('click', function () {
         if (pagesSection.childElementCount === 0) {
@@ -775,6 +778,12 @@ initATASquare();
         if (popup) {
           setTimeout(function () {
             popup.style.display = 'block';
+          }, 1000);
+        }
+        if (portalPanel && !portalShown) {
+          setTimeout(function () {
+            portalPanel.classList.add('visible');
+            portalShown = true;
           }, 1000);
         }
       });

--- a/style.css
+++ b/style.css
@@ -676,6 +676,27 @@
         margin-bottom: 8px;
     }
 
+    /* PORTAL panel styling */
+    #portalPanel {
+        display: none;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 300px;
+        height: 200px;
+        background-color: black;
+        border: 2px solid #00ff00;
+        font-family: monospace;
+        color: #00ff00;
+        padding: 20px;
+        z-index: 9999;
+    }
+
+    #portalPanel.visible {
+        display: block;
+    }
+
     @keyframes terminalExpand {
         0% { transform: scale(0.8); opacity: 0; }
         100% { transform: scale(1); opacity: 1; }


### PR DESCRIPTION
## Summary
- add new `#portalPanel` element for portal popup
- style `#portalPanel` like a terminal window
- show `#portalPanel` one second after clicking the logo

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853979dc7588326a793129d9096e61e