### PR TITLE
Fix PNG alignment after GIF in showManifesto

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,6 +234,14 @@ function showManifesto() {
         // After the GIF plays, replace it with the final static PNG and show the popup
         setTimeout(() => {
             animatedTitle.src = 'components/IMG_3412.png';
+            animatedTitle.style.position = 'absolute';
+            animatedTitle.style.top = '0';
+            animatedTitle.style.left = '0';
+            animatedTitle.style.zIndex = '10';
+            animatedTitle.style.opacity = '1';
+            animatedTitle.style.imageRendering = 'pixelated';
+            animatedTitle.style.maxWidth = '400px';
+            animatedTitle.style.height = 'auto';
             if (popup) {
                 popup.style.display = 'block';
             }


### PR DESCRIPTION
## Summary
- keep the animated title PNG from shifting after the GIF finishes
- set inline styles on `#animatedTitle` when switching GIF to final PNG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853a7d1b5b483268bcf70462cd2448e