### PR TITLE
Fix title container margin causing PNG jump

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
             
             <!-- Title Section -->
             <div class="text-center mb-8">
-                <div style="position: relative; display: inline-block; margin-top: -220px;" onclick="showManifesto()" id="titleContainer">
+                <div style="position: relative; display: inline-block;" onclick="showManifesto()" id="titleContainer">
                     <img src="Logopng.png" 
                          alt="GHOSTLINE"
                          style="image-rendering: pixelated; cursor: pointer; max-width: 400px; height: auto;"


### PR DESCRIPTION
## Summary
- update `#titleContainer` style to drop negative margin

## Testing
- `npm install`
- `npm start` *(server ran and was manually exited)*

------
https://chatgpt.com/codex/tasks/task_e_6853a99578dc8326bf15f9a573f2d198