### PR TITLE
Stabilize central layout and add debug overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         <div style="color: #666;">Copyright (c) 2025 Neural Networks Inc.</div>
         <div style="color: #666;">All rights reserved.</div>
         <div style="margin: 10px 0;"></div>
-    </div>
+        </div>
     
     <div style="margin: 20px 0;">
         <div style="border: 2px solid #00ff00; height: 20px; background: #000000; position: relative;">
@@ -107,6 +107,7 @@
 <main class="flex flex-col lg:flex-row p-4 h-full gap-6">
     <!-- Main Content (Left) -->
     <div class="w-full lg:w-3/4">
+        <div class="center-wrapper">
         <div class="flex flex-col items-center justify-center px-4">
             
             <!-- Logo Section -->
@@ -781,6 +782,12 @@ initATASquare();
       });
     }
   });
+</script>
+
+<script>
+if (window.location.search.includes("debug=true")) {
+  document.body.classList.add("debug");
+}
 </script>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -720,3 +720,25 @@
     margin-top: 8px;
 }
 
+.center-wrapper {
+  position: relative;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.portal-arch {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: -1;
+  pointer-events: none;
+}
+
+body.debug * {
+  outline: 1px solid rgba(0,255,0,0.1);
+}


### PR DESCRIPTION
## Summary
- wrap the main homepage elements in a new `.center-wrapper`
- define `.center-wrapper`, `.portal-arch`, and debug outline styles
- allow `?debug=true` to show element outlines

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853f48be8b08326b6b1c20681d87875