### PR TITLE
Fix showManifesto GIF visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,11 +247,13 @@
         // Reset GIF source to force a single play
         animatedTitle.src = '';
         animatedTitle.style.opacity = '1';
+        animatedTitle.style.display = 'block';
         animatedTitle.src = 'components/ghostline_pixel_noglow.gif';
 
         // After the GIF plays, replace it with the final PNG
         setTimeout(() => {
             animatedTitle.src = 'components/IMG_3412.png';
+            animatedTitle.style.display = 'block';
             if (popup) {
                 popup.style.display = 'block';
             }


### PR DESCRIPTION
## Summary
- reveal the manifesto GIF by ensuring it is visible when showManifesto() runs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685423e2542c83268212b6da2cc93387