### PR TITLE
Fix animated title GIF to play once

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,23 +229,21 @@ function showManifesto() {
         const finalTitle = document.getElementById('finalTitle');
 
         if (staticTitle && animatedTitle && finalTitle) {
-            // Hide static PNG and final PNG, show animated GIF
+            // Hide static PNG and final PNG, then show animated GIF
             staticTitle.style.opacity = '0';
             finalTitle.style.opacity = '0';
             animatedTitle.style.opacity = '1';
             animatedTitle.style.transform = 'scale(1.05)';
             animatedTitle.style.filter = 'drop-shadow(0 0 15px rgba(0, 255, 0, 0.8))';
-        }
 
-        // Show final PNG after animation
-        setTimeout(() => {
-            if (staticTitle && animatedTitle && finalTitle) {
+            // Hide the GIF after one cycle and reveal the final PNG
+            setTimeout(() => {
                 animatedTitle.style.opacity = '0';
                 animatedTitle.style.transform = 'scale(1)';
                 animatedTitle.style.filter = 'none';
                 finalTitle.style.opacity = '1';
-            }
-        }, 2000);
+            }, 1600);
+        }
     }
     
     // Create cosmic meteors - reduced intensity by 4x


### PR DESCRIPTION
## Summary
- tweak `showManifesto()` so the animated title GIF fades after one cycle

## Testing
- `npm start` *(fails: none)*

------
https://chatgpt.com/codex/tasks/task_e_6854463aff488326b98682ec2c5425df