### PR TITLE
Implement manifesto overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,11 @@
         <div id="terminal-close">X</div>
     </div>
     <div id="portalPanel">PORTAL ACTIVATED</div>
+    <div id="manifestoPanel">
+        <span class="manifesto-arrow manifesto-arrow-left">&#9664;</span>
+        <span class="manifesto-arrow manifesto-arrow-right">&#9654;</span>
+        <button id="manifestoNextBtn" class="manifesto-btn"></button>
+    </div>
 
 </main>
 
@@ -227,6 +232,7 @@ function showManifesto() {
         const staticTitle = document.getElementById('staticTitle');
         const animatedTitle = document.getElementById('animatedTitle');
         const finalTitle = document.getElementById('finalTitle');
+        const manifestoPanel = document.getElementById('manifestoPanel');
 
         if (staticTitle && animatedTitle && finalTitle) {
             // Hide static PNG and final PNG, then show animated GIF
@@ -244,6 +250,13 @@ function showManifesto() {
                 finalTitle.style.opacity = '1';
             }, 700);
         }
+
+        // Reveal manifesto panel after 1400ms
+        setTimeout(() => {
+            if (manifestoPanel) {
+                manifestoPanel.classList.add('visible');
+            }
+        }, 1400);
     }
     
     // Create cosmic meteors - reduced intensity by 4x

--- a/style.css
+++ b/style.css
@@ -701,6 +701,53 @@
         display: block;
     }
 
+    /* Manifesto overlay panel */
+    #manifestoPanel {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%) scale(0);
+        width: 60vw;
+        height: 60vh;
+        background: #000;
+        z-index: 10000;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        transition: transform 0.7s ease, opacity 0.7s ease;
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    #manifestoPanel.visible {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .manifesto-btn {
+        position: absolute;
+        right: 20px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 20px;
+        height: 20px;
+        background: red;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+    }
+
+    .manifesto-arrow {
+        position: absolute;
+        top: 50%;
+        font-size: 24px;
+        color: #fff;
+        transform: translateY(-50%);
+    }
+    .manifesto-arrow-left { left: 20px; }
+    .manifesto-arrow-right { right: 60px; }
+
     @keyframes terminalExpand {
         0% { transform: scale(0.8); opacity: 0; }
         100% { transform: scale(1); opacity: 1; }


### PR DESCRIPTION
## Summary
- add manifesto overlay markup and panel
- trigger overlay from `showManifesto`
- style manifesto panel and navigation hints

## Testing
- `npm install`
- `npm start` *(fails: server kept running, terminated manually)*

------
https://chatgpt.com/codex/tasks/task_e_6854c1071a688326838268706b653120