### PR TITLE
Add visible class and manifesto panel animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -701,8 +701,16 @@
         display: block;
     }
 
+    .visible {
+        transform: scale(1);
+        opacity: 1;
+        transition: transform 0.7s ease, opacity 0.7s ease;
+    }
+
+
     /* Manifesto overlay panel */
     #manifestoPanel {
+        transform-origin: center;
         position: fixed;
         top: 50%;
         left: 50%;


### PR DESCRIPTION
## Summary
- define a generic `.visible` class with transform & opacity transition
- update `#manifestoPanel` styles to use `transform-origin: center`
- keep the panel hidden initially with scale(0) and opacity 0

## Testing
- `npm install`
- `npm start` *(fails if dependencies missing, but should launch server)*

------
https://chatgpt.com/codex/tasks/task_e_6854c48dcfa483268a5aacea6d1dce1c