### PR TITLE
Adjust manifesto panel image

### DIFF
--- a/style.css
+++ b/style.css
@@ -871,12 +871,16 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 8px;
+    box-sizing: border-box;
 }
 #manifestoImage {
-    max-width: 100%;
-    max-height: 100%;
+    max-width: 90%;
+    max-height: 90%;
     display: none;
+    margin: auto;
     image-rendering: pixelated;
+    box-sizing: border-box;
 }
 .pixel-overlay {
     position: absolute;


### PR DESCRIPTION
## Summary
- keep manifesto image within the panel
- give the wrapper padding

## Testing
- `npm install`
- `npm start` *(fails: Module not found)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6854f2f4fd7c83268393d50bf03ddaea