### PR TITLE
Enhance manifesto layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GHOSTLINE: Learning Art with Robots</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Orbitron:wght@400;700;900&family=Audiowide&family=Russo+One&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=IBM+Plex+Mono:wght@400;700&family=Orbitron:wght@400;700;900&family=Audiowide&family=Russo+One&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 
     <style>
@@ -177,6 +177,7 @@
                 <div id="manifestoText"></div>
             </div>
         </div>
+        <div id="manifestoIndicator" class="manifesto-indicator">1 / 2</div>
         <div id="manifestoClose" class="manifesto-close">&#215;</div>
         <span class="manifesto-arrow manifesto-arrow-left">&#9664;</span>
         <span class="manifesto-arrow manifesto-arrow-right">&#9654;</span>
@@ -344,7 +345,7 @@ let currentManifestoSlide = 0;
         cursor.textContent = '_';
         element.appendChild(cursor);
 
-        const totalDuration = 400; // ms
+        const totalDuration = 800; // slower typewriter
         const chars = manifestoContent.split('');
         const delay = totalDuration / chars.length;
 
@@ -395,8 +396,12 @@ let currentManifestoSlide = 0;
         const text = document.getElementById('manifestoText');
         const loader = document.querySelector('#manifestoPanel .manifesto-loader');
         const loaderText = document.querySelector('#manifestoPanel .manifesto-loader-text');
+        const indicator = document.getElementById('manifestoIndicator');
 
         currentManifestoSlide = index;
+        if (indicator) {
+            indicator.textContent = (index + 1) + ' / 2';
+        }
 
         if (index === 0) {
             if (loader) loader.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -7,7 +7,8 @@
     html, body {
         background: #000000 !important;
         color: #00ff00;
-        font-family: 'Share Tech Mono', monospace;
+        font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+        font-weight: 700;
         margin: 0;
         padding: 0;
         min-height: 100%;
@@ -108,7 +109,8 @@
 }
 
     .logo-subtitle {
-        font-family: 'Share Tech Mono', monospace;
+        font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+        font-weight: 700;
         color: #00ff00;
         font-size: 14px;
         text-shadow: 0 0 2px #00ff00, 0 0 4px #00ff00;
@@ -119,7 +121,8 @@
     }
     
     .pixel-text-xs {
-        font-family: 'Share Tech Mono', monospace;
+        font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+        font-weight: 700;
         color: #66ff66;
         font-size: 10px;
         text-shadow: 0 0 2px rgba(102, 255, 102, 0.8), 
@@ -736,7 +739,8 @@
         box-sizing: border-box;
         border: 4px solid transparent;
         border-image: repeating-linear-gradient(45deg, #b200ff 0, #b200ff 10px, transparent 10px, transparent 20px) 8;
-        font-family: 'Share Tech Mono', monospace;
+        font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+        font-weight: 700;
         z-index: 10000;
         display: flex;
         justify-content: center;
@@ -744,6 +748,7 @@
         transition: transform 0.2s ease, opacity 0.2s ease;
         opacity: 0;
         pointer-events: none;
+        overflow: hidden;
     }
 
     #manifestoPanel.visible {
@@ -759,7 +764,8 @@
         top: 50%;
         font-size: 18px;
         color: #00ff00;
-        font-family: 'Share Tech Mono', monospace;
+        font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+        font-weight: 700;
         transform: translateY(-50%);
         cursor: pointer;
         opacity: 0;
@@ -780,7 +786,8 @@
         justify-content: center;
         border: 2px solid #ff0000;
         color: #ffffff;
-        font-family: 'Share Tech Mono', monospace;
+        font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+        font-weight: 700;
         cursor: pointer;
         opacity: 0;
         transition: opacity 0.2s ease;
@@ -859,7 +866,8 @@
     transition: width 0.3s linear;
 }
 .manifesto-loader-text {
-    font-family: 'Share Tech Mono', monospace;
+    font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+    font-weight: 700;
     color: #00ff00;
     font-size: 12px;
     margin-bottom: 4px;
@@ -901,9 +909,15 @@
     white-space: pre-wrap;
     color: #00ff00;
     text-align: center;
-    font-family: 'Share Tech Mono', monospace;
-    max-width: 90%;
+    font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+    font-weight: 700;
+    max-width: 100%;
+    max-height: 100%;
+    overflow-y: auto;
     margin: auto;
+    padding: 4px;
+    box-sizing: border-box;
+    word-break: break-word;
 }
 
 .crt-char {
@@ -915,6 +929,17 @@
     display: inline-block;
     color: #00ff00;
     animation: blinkCursor 0.7s steps(1, end) infinite;
+}
+
+.manifesto-indicator {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
+    font-weight: 700;
+    color: #00ff00;
+    font-size: 12px;
 }
 
 @keyframes crtBlink {


### PR DESCRIPTION
## Summary
- add page indicator for manifesto slides
- slow down typewriter effect
- switch manifesto fonts to IBM Plex Mono bold for terminal look
- constrain manifesto text inside panel

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6854fa30de8c8326aecadcd3fc18d44a