### PR TITLE
Fix GIF scaling in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                          alt="GHOSTLINE Logo"
                          id="logo"
                          class="enlarged-logo"
-                         style="max-width: 100%; height: auto; image-rendering: pixelated;">
+                         style="max-width: 100%; max-height: 100%; object-fit: contain; image-rendering: pixelated;">
                 </div>
             </div>
             

--- a/style.css
+++ b/style.css
@@ -212,9 +212,8 @@
     
     .enlarged-logo {
         max-width: 100%;
-        height: auto;
-        transform: scale(3.6);
-        transform-origin: center;
+        max-height: 100%;
+        object-fit: contain;
         filter: drop-shadow(0 0 8px rgba(0, 255, 0, 0.4));
         image-rendering: pixelated;
     }
@@ -458,7 +457,7 @@
         }
         
         .enlarged-logo {
-            transform: scale(2.8);
+            transform: none;
         }
         
         .w-48 {
@@ -540,7 +539,7 @@
         }
         
         .enlarged-logo {
-            transform: scale(2.4);
+            transform: none;
         }
         
         .w-48 {


### PR DESCRIPTION
## Summary
- tweak header logo style so GIF always fits within its green frame
- ensure responsive styles don't enlarge the GIF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685501581cf083268d01b9db87fd2103