### PR TITLE
Restore manifesto image reveal and update close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@
             </div>
             <div class="image-wrapper">
                 <img id="manifestoImage" src="pages/2Large.jpeg" alt="manifesto image">
+                <div id="pixelOverlay" class="pixel-overlay"></div>
                 <div id="manifestoText"></div>
             </div>
         </div>
@@ -368,6 +369,7 @@ let currentManifestoSlide = 0;
         const loader = document.querySelector('#manifestoPanel .manifesto-loader');
         const loaderText = document.querySelector('#manifestoPanel .manifesto-loader-text');
         const indicator = document.getElementById('manifestoIndicator');
+        const overlay = document.getElementById('pixelOverlay');
 
         currentManifestoSlide = index;
         if (indicator) {
@@ -379,8 +381,26 @@ let currentManifestoSlide = 0;
             if (loaderText) loaderText.style.display = 'none';
             if (text) text.style.display = 'none';
             if (image) image.style.display = 'block';
+            if (overlay) {
+                overlay.innerHTML = '';
+                overlay.style.display = 'grid';
+                const rows = 20;
+                const cols = 20;
+                overlay.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+                overlay.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+                for (let i = 0; i < rows * cols; i++) {
+                    const block = document.createElement('div');
+                    block.className = 'pixel-block';
+                    overlay.appendChild(block);
+                }
+                revealPixels(overlay);
+            }
         } else if (index === 1) {
             if (image) image.style.display = 'none';
+            if (overlay) {
+                overlay.style.display = 'none';
+                overlay.innerHTML = '';
+            }
             startManifestoLoading();
         }
     }
@@ -394,14 +414,15 @@ let currentManifestoSlide = 0;
     function revealPixels(overlay) {
         const blocks = Array.from(overlay.children);
         blocks.forEach(block => {
-            const delay = Math.random() * 200;
+            const delay = Math.random() * 500;
             setTimeout(() => {
                 block.style.opacity = '0';
             }, delay);
         });
         setTimeout(() => {
             overlay.style.display = 'none';
-        }, 500);
+            overlay.innerHTML = '';
+        }, 700);
     }
 
     // Create cosmic meteors - reduced intensity by 4x

--- a/style.css
+++ b/style.css
@@ -778,14 +778,13 @@
         position: absolute;
         top: 8px;
         right: 8px;
-        width: 16px;
-        height: 16px;
-        font-size: 11px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border: 2px solid #ff0000;
-        color: #ffffff;
+        width: 20px;
+        height: 20px;
+        font-size: 16px;
+        line-height: 20px;
+        text-align: center;
+        background: #0044ff;
+        color: #ff0000;
         font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
         font-weight: 700;
         cursor: pointer;
@@ -798,7 +797,7 @@
     }
 
     .manifesto-close:hover {
-        box-shadow: 0 0 4px #ff0000;
+        box-shadow: 0 0 4px #0044ff;
     }
 
     .manifesto-arrow:hover {
@@ -896,12 +895,15 @@
     left: 0;
     width: 100%;
     height: 100%;
+    pointer-events: none;
     display: none;
+    grid-template-columns: repeat(20, 1fr);
+    grid-template-rows: repeat(20, 1fr);
 }
 .pixel-block {
     background: #000;
     opacity: 1;
-    transition: opacity 0.4s linear;
+    transition: opacity 0.2s linear;
 }
 
 #manifestoText {


### PR DESCRIPTION
## Summary
- overlay pixel grid for manifesto image slide
- fade out pixels randomly over 700ms
- hide overlay when on text slide
- enlarge close button and use blue background with red cross

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_6855036152688326a53b1f4d33514441