### PR TITLE
Thicker manifesto panel border

### DIFF
--- a/style.css
+++ b/style.css
@@ -738,8 +738,8 @@
         background: #000;
         padding: 16px;
         box-sizing: border-box;
-        border: 4px solid transparent;
-        border-image: repeating-linear-gradient(45deg, #b200ff 0, #b200ff 10px, transparent 10px, transparent 20px) 8;
+        border: 12px solid transparent;
+        border-image: repeating-linear-gradient(45deg, #b200ff 0, #b200ff 30px, transparent 30px, transparent 60px) 24;
         font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
         font-weight: 700;
         z-index: 10000;


### PR DESCRIPTION
## Summary
- increase the border width of `#manifestoPanel`
- widen the diagonal stripe pattern to keep the purple frame consistent

## Testing
- `npm test` *(fails: Missing script)*
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68563a6645e48326b0d2b5536a6d58f4