### PR TITLE
Adjust manifesto panel sizing on tablets

### DIFF
--- a/style.css
+++ b/style.css
@@ -961,16 +961,18 @@
 }
 
 @media (min-width: 601px) and (max-width: 1024px) {
+    /* Slightly larger manifesto panel for tablets */
     #manifestoPanel {
-        width: 60vw;
-        height: 70vh;
+        width: 70vw;
+        height: 78vh;
         aspect-ratio: 3 / 4;
         margin: auto;
         box-sizing: border-box;
     }
     #manifestoImage {
         width: auto;
-        max-height: 80%;
+        max-width: 90%;
+        height: auto;
         display: block;
         margin: auto;
     }


### PR DESCRIPTION
## Summary
- enlarge `#manifestoPanel` and `#manifestoImage` for tablet viewports

## Testing
- `npm install`
- `npm start` *(server started then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_6857672cbcc48326beb945dfe2579ea3