### PR TITLE
Improve manifesto panel mobile styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -980,15 +980,22 @@
 
 @media (max-width: 600px) {
     #manifestoPanel {
-        width: 70vw;
-        height: 70vh;
+        width: 90vw;
+        height: 90vh;
         margin: auto;
         box-sizing: border-box;
     }
     #manifestoImage {
-        max-width: 85%;
+        width: 95%;
         height: auto;
+        max-width: none;
         display: block;
+        margin: auto;
+    }
+    #manifestoText {
+        font-size: 14px;
+        overflow-y: auto;
+        width: 95%;
         margin: auto;
     }
 }


### PR DESCRIPTION
## Summary
- adjust manifesto panel size on small screens
- scale manifesto images with no width cap
- tweak manifesto text for mobile readability

## Testing
- `npm start` *(fails: serve can't run due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68577873c0c08326b378f23320af67df