### PR TITLE
Update terminator draw gif with cache busting

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@ let currentManifestoSlide = 0;
                 overlay.innerHTML = '';
             }
             if (image) {
-                image.src = 'components/3scene-terminator-draw.gif';
+                image.src = 'components/3scene-terminator-draw.gif.gif?v=2';
                 image.style.display = 'block';
             }
         }


### PR DESCRIPTION
## Summary
- force cache refresh for 3scene-terminator-draw gif

## Testing
- `npm run start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685a2b77c354832684b6a5181da647cb