### PR TITLE
Add terminal-style fourth slide to manifesto

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
                 <div id="manifestoText"></div>
             </div>
         </div>
-        <div id="manifestoIndicator" class="manifesto-indicator">1 / 3</div>
+        <div id="manifestoIndicator" class="manifesto-indicator">1 / 4</div>
         <div id="manifestoClose" class="manifesto-close">&#215;</div>
         <span class="manifesto-arrow manifesto-arrow-left">&#9664;</span>
         <span class="manifesto-arrow manifesto-arrow-right">&#9654;</span>
@@ -376,7 +376,7 @@ let currentManifestoSlide = 0;
 
         currentManifestoSlide = index;
         if (indicator) {
-            indicator.textContent = (index + 1) + ' / 3';
+            indicator.textContent = (index + 1) + ' / 4';
         }
 
         if (index === 0) {
@@ -420,11 +420,24 @@ let currentManifestoSlide = 0;
                 image.src = 'components/3scene-terminator-draw.gif.gif?v=3';
                 image.style.display = 'block';
             }
+        } else if (index === 3) {
+            if (loader) loader.style.display = 'none';
+            if (loaderText) loaderText.style.display = 'none';
+            if (image) image.style.display = 'none';
+            if (overlay) {
+                overlay.style.display = 'none';
+                overlay.innerHTML = '';
+            }
+            if (text) {
+                text.style.display = 'block';
+                text.innerHTML =
+`▁▂▃▄▅▆▇█▇▆▅▄▃▂▁\n\nArt (even through AI) is not about ‘perfect parameters’, but about tuning the field where several waves coincide: desire, impulse, algorithm, randomness.`;
+            }
         }
     }
 
     function changeSlide(delta) {
-        const total = 3;
+        const total = 4;
         currentManifestoSlide = (currentManifestoSlide + delta + total) % total;
         showSlide(currentManifestoSlide);
     }

--- a/style.css
+++ b/style.css
@@ -784,8 +784,8 @@
         font-size: 16px;
         line-height: 20px;
         text-align: center;
-        background: #0044ff;
-        color: #ff0000;
+        background: #1a001a;
+        color: #00ff00;
         font-family: 'IBM Plex Mono', 'Share Tech Mono', monospace;
         font-weight: 700;
         cursor: pointer;
@@ -798,7 +798,7 @@
     }
 
     .manifesto-close:hover {
-        box-shadow: 0 0 4px #0044ff;
+        box-shadow: 0 0 4px #b200ff;
     }
 
     .manifesto-arrow:hover {


### PR DESCRIPTION
## Summary
- extend manifesto panel to 4 slides and update indicator
- implement new slide with terminal wave quote
- style close button with dark background and green text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac139acc8326a0a185437b127983