### PR TITLE
Add Open Graph meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,14 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=IBM+Plex+Mono:wght@400;700&family=Orbitron:wght@400;700;900&family=Audiowide&family=Russo+One&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
+    <meta property="og:title" content="GhostLine — Art & Info Ecosystem">
+    <meta property="og:description" content="Official GhostLine site: projects, visual experiments, art bots, automation, and more.">
+    <meta property="og:image" content="https://ghostline.live/og-image.png">
+    <meta property="og:url" content="https://ghostline.live">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="GhostLine — Art & Info Ecosystem">
+    <meta name="twitter:description" content="Official GhostLine site: projects, visual experiments, art bots, automation, and more.">
+    <meta name="twitter:image" content="https://ghostline.live/og-image.png">
 
     <style>
       #terminal-popup {


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter meta tags in the `<head>` of the homepage so GhostLine previews correctly on Telegram

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c365e61a88326951207960650afcd