### PR TITLE
Ensure artwork deletions persist in database

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -643,13 +643,20 @@ padding: 0.5rem;
         }
     }
 
-    function deleteArtwork(index) {
+    async function deleteArtwork(index) {
         const artwork = artworks[index];
         if (artwork && confirm('Delete selected artwork? This cannot be undone.')) {
-            artworks.splice(index, 1);
-            saveToLocalStorage();
-            loadArtworks();
-            alert('Artwork deleted!');
+            try {
+                if (window.supabaseAdmin && artwork.id) {
+                    await window.supabaseAdmin.deleteArtwork(artwork.id);
+                }
+                artworks.splice(index, 1);
+                saveToLocalStorage();
+                loadArtworks();
+                alert('Artwork deleted!');
+            } catch (error) {
+                alert('Failed to delete artwork: ' + (error.message || error));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- call Supabase delete API when removing an artwork
- keep local list in sync so deleted items don't reappear

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7ddc0b90c832685c2ac478e0e8378