### PR TITLE
fix: place artwork details below image on mobile

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -287,6 +287,23 @@
     .lightbox-contact-btn:hover {
         background: #0015FF;
     }
+
+    @media (max-width: 640px) {
+        .lightbox {
+            flex-direction: column;
+            padding: 20px 10px;
+        }
+
+        .lightbox img {
+            max-height: 60vh;
+        }
+
+        .lightbox-info {
+            position: static;
+            margin-top: 12px;
+            max-width: 90vw;
+        }
+    }
     
     /* Contact modal styles */
     .contact-modal {


### PR DESCRIPTION
## Summary
- prevent artwork details from overlapping image on mobile
- position details box below art with responsive layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e210f9908326894d2a433ef2e930