### PR TITLE
fix: scale manual modal to viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -733,8 +733,6 @@
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%) scaleY(0);
-        width: 31.5vw;
-        height: 31.5vh;
         background: #000;
         padding: 16px;
         box-sizing: border-box;
@@ -749,7 +747,9 @@
         transition: transform 0.2s ease, opacity 0.2s ease;
         opacity: 0;
         pointer-events: none;
-        overflow: hidden;
+        max-width: calc(100vw - 40px);
+        max-height: calc(100vh - 40px);
+        overflow: auto;
     }
 
     #manifestoPanel.visible {
@@ -883,10 +883,11 @@
     box-sizing: border-box;
 }
 #manifestoImage {
-    width: 100%;
+    width: auto;
     height: auto;
     max-width: 100%;
     max-height: 100%;
+    object-fit: contain;
     display: none;
     margin: auto;
     image-rendering: pixelated;
@@ -919,7 +920,7 @@
     font-weight: 700;
     max-width: 100%;
     max-height: 100%;
-    overflow: hidden;
+    overflow: auto;
     margin: auto;
     padding: 4px;
     box-sizing: border-box;
@@ -963,9 +964,8 @@
 @media (min-width: 601px) and (max-width: 1024px) {
     /* Slightly larger manifesto panel for tablets */
     #manifestoPanel {
-        width: 70vw;
-        height: 75vh;
-        aspect-ratio: 3 / 4;
+        max-width: calc(100vw - 40px);
+        max-height: calc(100vh - 40px);
         margin: auto;
         box-sizing: border-box;
     }
@@ -980,8 +980,8 @@
 
 @media (orientation: landscape) and (min-width: 768px) and (max-width: 1024px) {
     #manifestoPanel {
-        height: 90vh;
-        width: 60vw;
+        max-width: calc(100vw - 40px);
+        max-height: calc(100vh - 40px);
     }
 }
 
@@ -991,6 +991,7 @@
         height: 90vh;
         margin: auto;
         box-sizing: border-box;
+        overflow: hidden;
     }
     #manifestoImage {
         width: 95%;
@@ -1009,9 +1010,8 @@
 
 @media (min-width: 1025px) {
     #manifestoPanel {
-        width: 50vw;
-        height: 70vh;
-        aspect-ratio: 3 / 4;
+        max-width: calc(100vw - 80px);
+        max-height: calc(100vh - 80px);
         margin: auto;
     }
     #manifestoImage {


### PR DESCRIPTION
## Summary
- ensure manual modal container respects viewport with padding
- prevent cropping by constraining manual images and enabling scrolling when needed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7e44a36c483268869f68a5ca2db5c