### PR TITLE
fix: improve manual modal layout on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -1021,3 +1021,27 @@
         margin: auto;
     }
 }
+
+/* Desktop manual modal adjustments */
+@media (min-width: 1024px) {
+    .manual-wrap {
+        box-sizing: border-box;
+        max-width: calc(100vw - 80px);
+        max-height: calc(100vh - 80px);
+        margin: auto;
+        padding: 20px;
+        overflow: auto;
+    }
+
+    .manual-wrap img,
+    .manual-wrap video,
+    .manual-wrap canvas {
+        width: auto;
+        height: auto;
+        max-width: 100%;
+        max-height: 100%;
+        object-fit: contain;
+        display: block;
+        margin: auto;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure manual modal wrapper uses viewport-based sizing with scrollable overflow
- allow images, videos, and canvases to scale with object-fit contain on desktop

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e60a9b808326ada36917a6b5caed