### PR TITLE
Expand manual modal navigation and close hit areas

### DIFF
--- a/style.css
+++ b/style.css
@@ -1065,4 +1065,21 @@
         height: auto !important;
         object-fit: contain !important;
     }
+
+    .manual-modal .manual-close,
+    .manual-modal .manual-prev,
+    .manual-modal .manual-next,
+    .manual-modal .close,
+    .manual-modal .prev,
+    .manual-modal .next,
+    .manual-modal [data-action="close"],
+    .manual-modal [data-action="previous"],
+    .manual-modal [data-action="next"] {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 16px;
+        margin: -16px;
+    }
 }


### PR DESCRIPTION
## Summary
- Enlarge manual modal arrow and close button hitboxes without changing icon size for easier clicking on desktop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a7ef59fae48326b8d1ffc4d4404ba3