### PR TITLE
fix: prevent manual modal cropping

### DIFF
--- a/manual-modal.js
+++ b/manual-modal.js
@@ -43,20 +43,72 @@
     const media = wrap?.querySelector('img,video,canvas');
     if (!wrap) return;
 
-    ['width','height','transform','aspectRatio'].forEach(p => wrap.style[p] = '');
-    wrap.style.maxWidth = 'calc(100vw - 64px)';
-    wrap.style.maxHeight = 'calc(100vh - 64px)';
-    wrap.style.overflow = 'hidden';
+    ['width','height','transform','aspectRatio','maxWidth','maxHeight','overflow'].forEach(p => wrap.style[p] = '');
+    wrap.style.overflow = 'auto';
 
     if (media){
-      ['width','height'].forEach(p => media.style[p] = '');
-      media.style.maxWidth = '100%';
-      media.style.maxHeight = '100%';
+      ['width','height','maxWidth','maxHeight','objectFit'].forEach(p => media.style[p] = '');
       media.style.objectFit = 'contain';
       const ratio = getMediaAspectRatio(media);
       if (ratio) wrap.style.aspectRatio = ratio;
     }
   }
+
+  function closeModal(){
+    const btn = document.querySelector(
+      '.manual-modal .manual-close, .manual-modal .close, .manual-modal [data-action="close"]'
+    );
+    btn?.click();
+  }
+
+  function prevModal(){
+    const btn = document.querySelector(
+      '.manual-modal .manual-prev, .manual-modal .prev, .manual-modal [data-action="previous"]'
+    );
+    btn?.click();
+  }
+
+  function nextModal(){
+    const btn = document.querySelector(
+      '.manual-modal .manual-next, .manual-modal .next, .manual-modal [data-action="next"]'
+    );
+    btn?.click();
+  }
+
+  document.addEventListener('click', (e) => {
+    const modal = document.querySelector('.manual-modal');
+    if (!modal) return;
+    const style = getComputedStyle(modal);
+    if (style.display === 'none') return;
+    const controlSelector = [
+      '.manual-close',
+      '.manual-prev',
+      '.manual-next',
+      '.close',
+      '.prev',
+      '.next',
+      '[data-action="close"]',
+      '[data-action="previous"]',
+      '[data-action="next"]'
+    ].join(', ');
+    if (modal.contains(e.target) && !e.target.closest('.manual-wrap') && !e.target.closest(controlSelector)) {
+      closeModal();
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    const modal = document.querySelector('.manual-modal');
+    if (!modal) return;
+    const style = getComputedStyle(modal);
+    if (style.display === 'none') return;
+    if (e.key === 'Escape') {
+      closeModal();
+    } else if (e.key === 'ArrowLeft') {
+      prevModal();
+    } else if (e.key === 'ArrowRight') {
+      nextModal();
+    }
+  });
 
   window.normalizeManualModal = normalizeManualModal;
 

--- a/style.css
+++ b/style.css
@@ -1031,23 +1031,22 @@
         place-items: center;
         padding: 32px;
         background: rgba(0, 0, 0, .6);
+        overflow: auto;
+        z-index: 1000;
     }
 
-    .manual-modal,
     .manual-modal * {
         overflow: visible;
     }
 
     .manual-wrap {
         box-sizing: border-box;
-        max-width: calc(100vw - 64px);
-        max-height: calc(100vh - 64px);
         width: auto !important;
         height: auto !important;
         display: flex;
         align-items: center;
         justify-content: center;
-        overflow: hidden;
+        overflow: visible;
         background-color: #000;
         background-size: contain !important;
         background-position: center;
@@ -1063,8 +1062,6 @@
     .manual-wrap video,
     .manual-wrap canvas {
         display: block;
-        max-width: 100%;
-        max-height: 100%;
         width: auto !important;
         height: auto !important;
         object-fit: contain !important;
@@ -1083,7 +1080,21 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: 16px;
-        margin: -16px;
+        padding: 24px;
+        margin: -24px;
+        z-index: 1;
+    }
+
+    .manual-modal .manual-close:focus-visible,
+    .manual-modal .manual-prev:focus-visible,
+    .manual-modal .manual-next:focus-visible,
+    .manual-modal .close:focus-visible,
+    .manual-modal .prev:focus-visible,
+    .manual-modal .next:focus-visible,
+    .manual-modal [data-action="close"]:focus-visible,
+    .manual-modal [data-action="previous"]:focus-visible,
+    .manual-modal [data-action="next"]:focus-visible {
+        outline: 2px solid #fff;
+        outline-offset: 2px;
     }
 }


### PR DESCRIPTION
## Summary
- fix desktop manual modal by removing restrictive max sizes and allowing scrolling with contain scaling
- add outside click, ESC, and arrow key handlers for easier navigation
- expand manual control hit areas and add focus outlines for better accessibility

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8529c673083269e7679fee3281b9c